### PR TITLE
fix(deploy): healthchecks target 127.0.0.1 and document postgres credential pitfalls

### DIFF
--- a/docker/.env.prod.example
+++ b/docker/.env.prod.example
@@ -13,7 +13,13 @@ CORS_ORIGIN=https://studytune.example.com
 JWT_SECRET=change-me-strong-secret
 JWT_REFRESH_SECRET=change-me-strong-refresh-secret
 
-# --- PostgreSQL (values shared by the postgres container and the api) ---
+# --- PostgreSQL ---
+# ⚠️ Les 3 paires doivent être STRICTEMENT identiques : POSTGRES_* configure le conteneur
+# postgres, DB_* configure l'API qui s'y connecte. Une valeur différente donne
+# "password authentication failed for user".
+# ⚠️ PostgreSQL n'applique POSTGRES_PASSWORD qu'à la PREMIÈRE initialisation du volume.
+# Si le mot de passe est changé après un premier démarrage, il faut recréer le volume :
+# docker compose -f docker/docker-compose.prod.yml down -v   (⚠️ efface la base)
 POSTGRES_USER=studytune
 POSTGRES_PASSWORD=change-me-strong-db-password
 POSTGRES_DB=studytune

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -25,7 +25,7 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:3001/api/health || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3001/api/health || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -35,7 +35,7 @@ services:
       context: ../client
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:80/ || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:80/ || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docs/manuel-deploiement.md
+++ b/docs/manuel-deploiement.md
@@ -146,6 +146,14 @@ démarrage** de l'API. Pour les lancer manuellement :
 docker compose -f docker/docker-compose.prod.yml exec api npm run migration:run
 ```
 
+### Dépannage
+
+| Symptôme | Cause | Correction |
+|---|---|---|
+| `password authentication failed for user` dans les logs postgres | `DB_PASSWORD` ≠ `POSTGRES_PASSWORD`, **ou** volume `pgdata` initialisé lors d'un essai précédent avec un autre mot de passe (PostgreSQL ne l'applique qu'à la première initialisation) | Aligner les deux valeurs dans `.env.prod`, puis recréer le volume : `docker compose -f docker/docker-compose.prod.yml down -v` puis `up -d --build` (⚠️ `-v` efface la base) |
+| `dependency failed to start` sur un service | Un service dont il dépend n'est jamais devenu *healthy* | Regarder `docker compose -f docker/docker-compose.prod.yml ps -a` pour identifier lequel, puis ses logs |
+| Conteneur `unhealthy` alors que le service répond | Healthcheck visant `localhost` alors que le process n'écoute qu'en IPv4 | Les healthchecks utilisent `127.0.0.1` (et non `localhost`) pour cette raison |
+
 ### Vérifications
 
 ```bash


### PR DESCRIPTION
Correctifs suite au premier déploiement sur le VPS OVH.

## 1. Healthchecks `unhealthy` à tort (bug du compose de prod)

Les healthchecks visaient `http://localhost:...`, mais nginx (client) n'écoute qu'en **IPv4** (`0.0.0.0:80`) alors que `localhost` résout d'abord en `::1` (IPv6) → `Connection refused` → conteneur marqué `unhealthy` → Caddy (qui dépend de `api: service_healthy`) reste bloqué en `Created`.

Reproduit et confirmé sur l'image client :
- `wget http://localhost:80/` → `Connection refused` (exit 1)
- `wget http://127.0.0.1:80/` → exit 0

Les healthchecks `api` et `client` utilisent désormais `127.0.0.1`.

## 2. Documentation du piège des identifiants PostgreSQL

Symptôme rencontré : `password authentication failed for user "studytune"` alors que le conteneur postgres est *healthy* (`pg_isready` ne vérifie pas le mot de passe).

Deux causes documentées :
- `DB_PASSWORD` ≠ `POSTGRES_PASSWORD` (les deux jeux de variables doivent être identiques) ;
- volume `pgdata` initialisé lors d'un essai précédent : PostgreSQL n'applique `POSTGRES_PASSWORD` qu'à la **première** initialisation.

Ajouté :
- `docker/.env.prod.example` : avertissements explicites sur les 3 paires à aligner et sur le volume déjà initialisé ;
- `docs/manuel-deploiement.md` : section **Dépannage** (3 symptômes → cause → correction).

## Après merge

Sur le VPS :
```bash
cd ~/study-tune && git pull
docker compose -f docker/docker-compose.prod.yml down -v
docker compose -f docker/docker-compose.prod.yml up -d --build
```