### PR TITLE
ci(deploy): continuous deployment to the OVH VPS on version tags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,100 @@
+name: Deploy
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  REGISTRY: ghcr.io
+  API_IMAGE: ghcr.io/${{ github.repository_owner }}/study-tune-api
+  CLIENT_IMAGE: ghcr.io/${{ github.repository_owner }}/study-tune-client
+
+jobs:
+  build:
+    name: Build and push images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push the api image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./api
+          push: true
+          tags: |
+            ${{ env.API_IMAGE }}:${{ github.ref_name }}
+            ${{ env.API_IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push the client image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./client
+          push: true
+          tags: |
+            ${{ env.CLIENT_IMAGE }}:${{ github.ref_name }}
+            ${{ env.CLIENT_IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy to the OVH VPS
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull the tagged images and restart the stack
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
+            set -e
+            cd ~/study-tune
+            git fetch origin --tags --prune
+            git checkout main
+            git pull --ff-only origin main
+            if [ -n "${{ secrets.GHCR_TOKEN }}" ]; then
+              echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            fi
+            export IMAGE_TAG=${{ github.ref_name }}
+            docker compose -f docker/docker-compose.prod.yml pull api client
+            docker compose -f docker/docker-compose.prod.yml up -d --no-build
+            docker compose -f docker/docker-compose.prod.yml ps
+
+      - name: Verify the API health endpoint
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
+            set -e
+            cd ~/study-tune
+            for attempt in $(seq 1 12); do
+              if docker compose -f docker/docker-compose.prod.yml exec -T api \
+                   wget -qO- http://127.0.0.1:3001/api/health | grep -q '"status":"ok"'; then
+                echo "API healthy"
+                exit 0
+              fi
+              echo "waiting for the api to become healthy ($attempt/12)"
+              sleep 5
+            done
+            echo "API did not become healthy"
+            docker compose -f docker/docker-compose.prod.yml logs api --tail=50
+            exit 1

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -13,6 +13,7 @@ services:
       retries: 10
 
   api:
+    image: ghcr.io/ramenard/study-tune-api:${IMAGE_TAG:-latest}
     build: ../api
     restart: unless-stopped
     env_file:
@@ -31,6 +32,7 @@ services:
       retries: 5
 
   client:
+    image: ghcr.io/ramenard/study-tune-client:${IMAGE_TAG:-latest}
     build:
       context: ../client
     restart: unless-stopped

--- a/docs/manuel-deploiement.md
+++ b/docs/manuel-deploiement.md
@@ -146,6 +146,46 @@ démarrage** de l'API. Pour les lancer manuellement :
 docker compose -f docker/docker-compose.prod.yml exec api npm run migration:run
 ```
 
+### Déploiement continu (tag → production)
+
+Le workflow `.github/workflows/deploy.yml` se déclenche sur le **push d'un tag `v*`** :
+
+1. **Job `build`** : construit les images `api` et `client` et les pousse sur **GHCR**
+   (`ghcr.io/<owner>/study-tune-api` et `study-tune-client`), taguées `<tag>` **et** `latest`,
+   avec cache de build GitHub Actions.
+2. **Job `deploy`** : se connecte au VPS en SSH, met à jour le dépôt (`main`), tire les images du
+   tag (`IMAGE_TAG=<tag> docker compose pull`), redémarre la stack (`up -d --no-build`), puis
+   **vérifie `/api/health`** en boucle (12 essais) et affiche les logs de l'api en cas d'échec.
+
+Secrets à créer dans *Settings → Secrets and variables → Actions* :
+
+| Secret | Rôle |
+|---|---|
+| `VPS_HOST` | IP ou nom d'hôte du VPS |
+| `VPS_USER` | utilisateur SSH (`deploy`) |
+| `VPS_SSH_KEY` | clé privée SSH autorisée sur le VPS |
+| `GHCR_TOKEN` | **optionnel** : PAT avec `read:packages`, uniquement si les images GHCR sont privées |
+
+Publier une version :
+
+```bash
+git tag -a v1.0.0 -m "v1.0.0"
+git push origin v1.0.0
+```
+
+> **Migrations** : aucune étape manuelle dans le workflow. En production `NODE_ENV=production`
+> active `migrationsRun`, donc l'API applique les migrations **au démarrage** depuis
+> `dist/migrations/*.js`. Un `npm run migration:run` dans le conteneur de production échouerait :
+> l'image runtime ne contient ni `src/` ni `ts-node` (dépendances de développement omises).
+
+**Rollback** : redéployer un tag antérieur sans repasser par la CI —
+
+```bash
+cd ~/study-tune
+IMAGE_TAG=v0.9.0 docker compose -f docker/docker-compose.prod.yml pull api client
+IMAGE_TAG=v0.9.0 docker compose -f docker/docker-compose.prod.yml up -d --no-build
+```
+
 ### Dépannage
 
 | Symptôme | Cause | Correction |


### PR DESCRIPTION
Phase 6 du plan de déploiement OVH : déploiement continu déclenché par un tag de version.

## Workflow `.github/workflows/deploy.yml`

Déclencheur : **push d'un tag `v*`**.

1. **Job `build`** — construit les images `api` et `client` et les pousse sur **GHCR**
   (`ghcr.io/<owner>/study-tune-api` / `study-tune-client`), taguées `<tag>` **et** `latest`,
   avec cache de build GitHub Actions (`type=gha`).
2. **Job `deploy`** (`needs: build`) — SSH sur le VPS : `git pull` de `main`, `docker compose pull`
   des images du tag (`IMAGE_TAG`), `up -d --no-build`, puis **vérification de `/api/health`**
   en boucle (12 essais) avec affichage des logs de l'api en cas d'échec.

## Compose de production

`api` et `client` référencent désormais les images GHCR avec **fallback `build:`** :

```yaml
image: ghcr.io/ramenard/study-tune-api:${IMAGE_TAG:-latest}
build: ../api
```

Le premier déploiement (`up -d --build`) fonctionne donc toujours sans registre, et les
déploiements suivants tirent l'image du tag. Le rollback consiste à relancer avec un `IMAGE_TAG`
antérieur.

## Point d'attention : migrations

Le plan prévoyait `exec api npm run migration:run` dans le script de déploiement. **Cette commande
échouerait** : l'image runtime ne contient ni `src/` ni `ts-node` (dépendances de dev omises), or
le script utilise `typeorm-ts-node-commonjs -d src/data-source.ts`.

C'est inutile de toute façon : en production `NODE_ENV=production` active `migrationsRun`, donc
l'API applique les migrations **au démarrage** depuis `dist/migrations/*.js`. L'étape a donc été
retirée et le comportement documenté.

## Secrets à créer

| Secret | Rôle |
|---|---|
| `VPS_HOST` | IP / hôte du VPS |
| `VPS_USER` | utilisateur SSH (`deploy`) |
| `VPS_SSH_KEY` | clé privée SSH |
| `GHCR_TOKEN` | **optionnel** — PAT `read:packages`, seulement si les images GHCR sont privées (le login est conditionnel) |

## Validation

- `deploy.yml` : YAML valide, jobs `build` + `deploy`.
- Interpolation vérifiée : `IMAGE_TAG=v9.9.9` → `ghcr.io/ramenard/study-tune-api:v9.9.9` ; sans variable → `:latest`.
- `docker compose config` toujours valide.

## Documentation

`docs/manuel-deploiement.md` : section **Déploiement continu** (workflow, secrets, publication d'une version, note migrations, procédure de rollback).